### PR TITLE
Chore/add ignore changes

### DIFF
--- a/nat.tf
+++ b/nat.tf
@@ -1,12 +1,3 @@
-module "nat_label" {
-  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
-  delimiter = "${var.delimiter}"
-  tags      = "${var.tags}"
-}
-
 locals {
   nat_gateways_count = "${var.nat_gateway_enabled == "true" ? length(var.availability_zones) : 0}"
 }
@@ -18,6 +9,7 @@ resource "aws_eip" "default" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = ["tags"]
   }
 }
 
@@ -25,7 +17,6 @@ resource "aws_nat_gateway" "default" {
   count         = "${local.nat_gateways_count}"
   allocation_id = "${element(aws_eip.default.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
-  tags          = "${module.nat_label.tags}"
 
   lifecycle {
     create_before_destroy = true

--- a/private.tf
+++ b/private.tf
@@ -12,8 +12,7 @@ module "private_subnet_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = ["private"]
+  name       = "private"
   tags       = "${var.tags}"
 }
 
@@ -28,6 +27,10 @@ resource "aws_subnet" "private" {
   cidr_block        = "${cidrsubnet(signum(length(var.cidr_block)) == 1 ? var.cidr_block : data.aws_vpc.default.cidr_block, ceil(log(local.private_subnet_count * 2, 2)), count.index)}"
 
   tags = "${merge(module.private_subnet_label.tags, map("Name",format("%s%s%s", module.private_subnet_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }
 
 resource "aws_route_table" "private" {
@@ -35,6 +38,10 @@ resource "aws_route_table" "private" {
   vpc_id = "${data.aws_vpc.default.id}"
 
   tags = "${module.private_label.tags}"
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }
 
 resource "aws_route_table_association" "private" {
@@ -68,4 +75,8 @@ resource "aws_network_acl" "private" {
   }
 
   tags = "${module.private_label.tags}"
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }

--- a/public.tf
+++ b/public.tf
@@ -12,8 +12,7 @@ module "public_subnet_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
-  name       = "${var.name}"
-  attributes = ["public"]
+  name       = "public"
   tags       = "${var.tags}"
 }
 
@@ -28,6 +27,10 @@ resource "aws_subnet" "public" {
   cidr_block        = "${cidrsubnet(signum(length(var.cidr_block)) == 1 ? var.cidr_block : data.aws_vpc.default.cidr_block, ceil(log(local.public_subnet_count * 2, 2)), local.public_subnet_count + count.index)}"
 
   tags = "${merge(module.public_subnet_label.tags, map("Name",format("%s%s%s", module.public_subnet_label.id, var.delimiter, replace(element(var.availability_zones, count.index),"-",var.delimiter))))}"
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }
 
 resource "aws_route_table" "public" {
@@ -35,6 +38,10 @@ resource "aws_route_table" "public" {
   vpc_id = "${data.aws_vpc.default.id}"
 
   tags = "${module.public_label.tags}"
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }
 
 resource "aws_route" "public" {
@@ -80,4 +87,8 @@ resource "aws_network_acl" "public" {
   }
 
   tags = "${module.public_label.tags}"
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }

--- a/public.tf
+++ b/public.tf
@@ -36,19 +36,16 @@ resource "aws_subnet" "public" {
 resource "aws_route_table" "public" {
   count  = "${signum(length(var.vpc_default_route_table_id)) == 1 ? 0 : 1}"
   vpc_id = "${data.aws_vpc.default.id}"
-
   tags = "${module.public_label.tags}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${var.igw_id}"
+  }
 
   lifecycle {
     ignore_changes = ["tags"]
   }
-}
-
-resource "aws_route" "public" {
-  count                  = "${signum(length(var.vpc_default_route_table_id)) == 1 ? 0 : 1}"
-  route_table_id         = "${join("", aws_route_table.public.*.id)}"
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${var.igw_id}"
 }
 
 resource "aws_route_table_association" "public" {


### PR DESCRIPTION
## what
- Adds `ignore_changes` to all tags, so we aren't forced to unnecessarily rename resources.

## why
- We require the variable `max_subnet_count` which became available in v0.3.5 but the naming scheme in v0.3.5 changed, which would result in undesirable effects for us.